### PR TITLE
Add base FastAPI app and android placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,16 @@ pip install -r requirements.txt
 ### Running the application
 - **Backend**
   ```bash
-  uvicorn app.main:app --reload  # Placeholder path
+  uvicorn app.main:app --reload
   ```
 - **Android app**
   ```bash
+  cd android-app
   ./gradlew installDebug
   adb shell am start -n com.example.diary/.MainActivity
   ```
 
-These commands are placeholders until the app code is added.
+These commands assume the backend lives in `app/` and the Android project in `android-app/`.
 
 ## License
 MIT

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add minimal FastAPI application with `/health` endpoint
- create `android-app` placeholder directory
- update README instructions for running backend and Android app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855624d01b48324a727a2c93de2c372