### PR TITLE
Add SQLite database utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains experimental code and documentation for the **Dear Diar
 
 ### Backend
 - **Python + FastAPI** for a lightweight API layer.
+- **SQLite with SQLAlchemy** for simple local persistence.
 
 ### Mobile Client
 - **Kotlin + Jetpack Compose** for a modern Android interface.
@@ -27,8 +28,11 @@ cd dee
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt  
+pip install -r requirements.txt
 ```
+
+The API uses a local SQLite database located at `data.db`. Tables are created
+automatically on startup.
 
 ### Android environment
 1. Install Android Studio with SDK tools and a recent Kotlin setup.
@@ -47,6 +51,22 @@ pip install -r requirements.txt
   ```
 
 These commands assume the backend lives in `app/` and the Android project in `android-app/`.
+
+### Working with the database
+
+`app.db_utils` exposes helper functions to log and query prohibited actions.
+Example:
+
+```python
+from app.database import SessionLocal
+from app.db_utils import log_prohibited_action
+
+db = SessionLocal()
+log_prohibited_action(db, "Attempted restricted feature", performed_by="user42")
+db.close()
+```
+
+Use the `/prohibited-actions` endpoints to create and fetch entries via the API.
 
 ## License
 MIT

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,15 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./data.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/app/db_utils.py
+++ b/app/db_utils.py
@@ -1,0 +1,15 @@
+from sqlalchemy.orm import Session
+
+from .models import ProhibitedAction
+
+
+def log_prohibited_action(db: Session, description: str, performed_by: str | None = None) -> ProhibitedAction:
+    action = ProhibitedAction(description=description, performed_by=performed_by)
+    db.add(action)
+    db.commit()
+    db.refresh(action)
+    return action
+
+
+def list_prohibited_actions(db: Session, limit: int = 100):
+    return db.query(ProhibitedAction).order_by(ProhibitedAction.timestamp.desc()).limit(limit).all()

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,42 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal, init_db
+from .db_utils import log_prohibited_action, list_prohibited_actions
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize database tables."""
+    init_db()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+
+@app.post("/prohibited-actions")
+def create_prohibited_action(description: str, performed_by: str | None = None, db: Session = Depends(get_db)):
+    action = log_prohibited_action(db, description, performed_by)
+    return {
+        "id": action.id,
+        "description": action.description,
+        "timestamp": action.timestamp,
+        "performed_by": action.performed_by,
+    }
+
+
+@app.get("/prohibited-actions")
+def get_prohibited_actions(limit: int = 100, db: Session = Depends(get_db)):
+    actions = list_prohibited_actions(db, limit)
+    return actions

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime
+
+from .database import Base
+
+class ProhibitedAction(Base):
+    __tablename__ = "prohibited_actions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    performed_by = Column(String, nullable=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 openai
 python-dotenv
+SQLAlchemy


### PR DESCRIPTION
## Summary
- add SQLAlchemy dependency
- initialize SQLite connection and ProhibitedAction model
- expose CRUD helper functions and API endpoints
- document DB usage in README

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_685564c627c48324896366a655115780