### PR TITLE
Initialize backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Dear Diary
+
+Project structure for Dear Diary application with a FastAPI backend.
+
+## Backend setup
+
+```
+cd dear-diary/backend
+python -m venv venv
+source venv/bin/activate  # or venv\Scripts\activate on Windows
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```

--- a/dear-diary/backend/app/main.py
+++ b/dear-diary/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"message": "Welcome to Dear Diary API"}

--- a/dear-diary/backend/requirements.txt
+++ b/dear-diary/backend/requirements.txt
@@ -1,0 +1,12 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+alembic
+psycopg2-binary
+pydantic[email]
+python-dotenv
+celery
+redis
+passlib[bcrypt]
+python-jose[cryptography]
+httpx


### PR DESCRIPTION
## Summary
- add README with backend instructions
- add initial FastAPI app with placeholder endpoint
- specify backend requirements

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685569f32ae883248c3a8876fd9bd00f